### PR TITLE
fix tooltip text

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -67,7 +67,7 @@ const updateIcon = async function updateIcon () {
 
     // Update the tooltip
     browser.browserAction.setTitle({
-      title: `Tab Counter\nTabs in this window:  ${currentWindow}\nTabs in all windows: ${allTabs}\nNumber of windows: ${allWindows}`,
+      title: `Tab Counter\nTabs in this window:  ${tabsInCurrentWindow}\nTabs in all windows: ${allTabs}\nNumber of windows: ${allWindows}`,
       windowId: currentWindow.id
     })
   }


### PR DESCRIPTION
the tooltip currently says `Tabs in current window: [object Object]` because this commit https://github.com/vhfmag/tab-counter/commit/e67889f630930e98537b8a050d1cc30122b55d38 forgot to also change this variable